### PR TITLE
Bump lzma-rs to use version with fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,8 +94,8 @@ dependencies = [
 
 [[package]]
 name = "lzma-rs"
-version = "0.1.1"
-source = "git+git://github.com/dragly/lzma-rs/?rev=2dbbdee321a5d1de45123ee986f551431b0aacf2#2dbbdee321a5d1de45123ee986f551431b0aacf2"
+version = "0.1.2"
+source = "git+git://github.com/dragly/lzma-rs/?rev=0117fcdecf55de9a7a95d855d0be388afd109aae#0117fcdecf55de9a7a95d855d0be388afd109aae"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -188,7 +188,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lzma-rs 0.1.1 (git+git://github.com/dragly/lzma-rs/?rev=2dbbdee321a5d1de45123ee986f551431b0aacf2)",
+ "lzma-rs 0.1.2 (git+git://github.com/dragly/lzma-rs/?rev=0117fcdecf55de9a7a95d855d0be388afd109aae)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -368,7 +368,7 @@ dependencies = [
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-"checksum lzma-rs 0.1.1 (git+git://github.com/dragly/lzma-rs/?rev=2dbbdee321a5d1de45123ee986f551431b0aacf2)" = "<none>"
+"checksum lzma-rs 0.1.2 (git+git://github.com/dragly/lzma-rs/?rev=0117fcdecf55de9a7a95d855d0be388afd109aae)" = "<none>"
 "checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
 "checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ clap = "2.33.0"
 serde_yaml = "0.8.9"
 
 [dependencies.lzma-rs]
-rev = "2dbbdee321a5d1de45123ee986f551431b0aacf2"
+rev = "0117fcdecf55de9a7a95d855d0be388afd109aae"
 git = "git://github.com/dragly/lzma-rs/"

--- a/src/bin/dump.rs
+++ b/src/bin/dump.rs
@@ -2,9 +2,9 @@ use clap::clap_app;
 use openctm;
 use serde_json;
 use serde_yaml;
+use std::error::Error;
 use std::fs::File;
 use std::io::{stdin, stdout, Read};
-use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let matches = clap_app!(("openctm-dump") =>

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ impl std::error::Error for Error {}
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Error {
         Error {
-            message: format!("IO error {}", err)
+            message: format!("IO error {}", err),
         }
     }
 }
@@ -32,7 +32,7 @@ impl From<std::io::Error> for Error {
 impl From<std::str::Utf8Error> for Error {
     fn from(err: std::str::Utf8Error) -> Error {
         Error {
-            message: format!("UTF8 error {}", err)
+            message: format!("UTF8 error {}", err),
         }
     }
 }
@@ -43,8 +43,8 @@ impl From<lzma_rs::error::Error> for Error {
             message: match err {
                 lzma_rs::error::Error::IOError(x) => format!("IO error from LZMA {}", x),
                 lzma_rs::error::Error::LZMAError(x) => format!("LZMAError {}", x),
-                lzma_rs::error::Error::XZError(x) => format!("XZError {}", x)
-            }
+                lzma_rs::error::Error::XZError(x) => format!("XZError {}", x),
+            },
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,18 @@ impl From<std::str::Utf8Error> for Error {
     }
 }
 
+impl From<lzma_rs::error::Error> for Error {
+    fn from(err: lzma_rs::error::Error) -> Error {
+        Error {
+            message: match err {
+                lzma_rs::error::Error::IOError(x) => format!("IO error from LZMA {}", x),
+                lzma_rs::error::Error::LZMAError(x) => format!("LZMAError {}", x),
+                lzma_rs::error::Error::XZError(x) => format!("XZError {}", x)
+            }
+        }
+    }
+}
+
 macro_rules! error {
     ($($args:tt)*) => { $crate::error::Error::new(format!($($args)*)) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@ impl PartialEq for TextureCoordinate {
 impl PartialEq for UvMap {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
-        && self.file_name == other.file_name
-        && self.coordinates == other.coordinates
+            && self.file_name == other.file_name
+            && self.coordinates == other.coordinates
     }
 }
 
@@ -126,7 +126,11 @@ pub trait ReadExt: io::Read {
         Ok(str::from_utf8(&result)?.to_string())
     }
 
-    fn read_packed_data(&mut self, unpacked_size: usize, interleaved_byte_count: usize) -> Result<Vec<u8>, Error> {
+    fn read_packed_data(
+        &mut self,
+        unpacked_size: usize,
+        interleaved_byte_count: usize,
+    ) -> Result<Vec<u8>, Error> {
         let packed_data_size = self.read_i32::<LittleEndian>()? as usize;
         let packed_data_size_with_header = packed_data_size + LZMA_HEADER_SIZE;
 
@@ -142,7 +146,9 @@ pub trait ReadExt: io::Read {
             &mut cursor,
             &mut writer,
             &lzma_rs::decompress::Options {
-                unpacked_size: lzma_rs::decompress::UnpackedSize::UseProvided(Some(unpacked_size as u64)),
+                unpacked_size: lzma_rs::decompress::UnpackedSize::UseProvided(Some(
+                    unpacked_size as u64,
+                )),
             },
         )?;
         Ok(decomp)

--- a/tests/box.rs
+++ b/tests/box.rs
@@ -88,43 +88,41 @@ mod tests {
             0 as u32, 1, 3, 1, 2, 3, 2, 6, 7, 2, 7, 3, 2, 10, 6, 3, 7, 11, 3, 11, 9, 4, 5, 8, 5, 6,
             10, 5, 10, 8, 6, 13, 7, 7, 13, 12,
         ];
-        let uv_maps = vec![
-            UvMap {
-                name: "Diffuse color".into(),
-                file_name: "".into(),
-                coordinates: vec![
-                    TextureCoordinate { u: 0.25, v: 0.5 },
-                    TextureCoordinate { u: 0.5, v: 0.25 },
-                    TextureCoordinate { u: 1.0, v: 0.75 },
-                    TextureCoordinate { u: 0.5, v: 0.25 },
-                    TextureCoordinate { u: 1.0, v: 0.0 },
-                    TextureCoordinate { u: 0.75, v: 0.0 },
-                    TextureCoordinate { u: 0.25, v: 0.5 },
-                    TextureCoordinate { u: 0.0, v: 0.0 },
-                    TextureCoordinate {
-                        u: 0.3333333,
-                        v: 0.3333333,
-                    },
-                    TextureCoordinate {
-                        u: 0.6666667,
-                        v: 0.6666667,
-                    },
-                    TextureCoordinate {
-                        u: 0.6666667,
-                        v: 0.6666667,
-                    },
-                    TextureCoordinate {
-                        u: 0.3333333,
-                        v: 0.3333333,
-                    },
-                    TextureCoordinate {
-                        u: 0.3333333,
-                        v: 0.6666667,
-                    },
-                    TextureCoordinate { u: 1.0, v: 1.0 },
-                ],
-            },
-        ];
+        let uv_maps = vec![UvMap {
+            name: "Diffuse color".into(),
+            file_name: "".into(),
+            coordinates: vec![
+                TextureCoordinate { u: 0.25, v: 0.5 },
+                TextureCoordinate { u: 0.5, v: 0.25 },
+                TextureCoordinate { u: 1.0, v: 0.75 },
+                TextureCoordinate { u: 0.5, v: 0.25 },
+                TextureCoordinate { u: 1.0, v: 0.0 },
+                TextureCoordinate { u: 0.75, v: 0.0 },
+                TextureCoordinate { u: 0.25, v: 0.5 },
+                TextureCoordinate { u: 0.0, v: 0.0 },
+                TextureCoordinate {
+                    u: 0.3333333,
+                    v: 0.3333333,
+                },
+                TextureCoordinate {
+                    u: 0.6666667,
+                    v: 0.6666667,
+                },
+                TextureCoordinate {
+                    u: 0.6666667,
+                    v: 0.6666667,
+                },
+                TextureCoordinate {
+                    u: 0.3333333,
+                    v: 0.3333333,
+                },
+                TextureCoordinate {
+                    u: 0.3333333,
+                    v: 0.6666667,
+                },
+                TextureCoordinate { u: 1.0, v: 1.0 },
+            ],
+        }];
 
         assert_eq!(reader.vertices, vertices);
         assert_eq!(reader.indices, indices);


### PR DESCRIPTION
... such as range coding error and LZCircularBuffer allocation.
This also has a proper implementation for specifying unpacked size.

Also take into account that the end of the stream should be at the
next component type.