### PR TITLE
Move lzma-rs to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,8 +107,8 @@ dependencies = [
 
 [[package]]
 name = "lzma-rs"
-version = "0.1.2"
-source = "git+git://github.com/gendx/lzma-rs/?rev=3fcf0bbfc5f13f22a35d397c568387ec4cfac8e4#3fcf0bbfc5f13f22a35d397c568387ec4cfac8e4"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -200,7 +200,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lzma-rs 0.1.2 (git+git://github.com/gendx/lzma-rs/?rev=3fcf0bbfc5f13f22a35d397c568387ec4cfac8e4)",
+ "lzma-rs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -455,7 +455,7 @@ dependencies = [
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-"checksum lzma-rs 0.1.2 (git+git://github.com/gendx/lzma-rs/?rev=3fcf0bbfc5f13f22a35d397c568387ec4cfac8e4)" = "<none>"
+"checksum lzma-rs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "adc181f57e3b64bb860c476fe5751eb6f60e9fcf588b1447e24c0757c1c3101f"
 "checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
 "checksum num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57450397855d951f1a41305e54851b1a7b8f5d2e349543a02a2effe25459f718"
 "checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,4 @@ clap = "2.33.0"
 serde_yaml = "0.8.9"
 structopt = "0.3.9"
 serde_derive = "1.0.104"
-
-[dependencies.lzma-rs]
-rev = "3fcf0bbfc5f13f22a35d397c568387ec4cfac8e4"
-git = "git://github.com/gendx/lzma-rs/"
+lzma-rs = "0.1.3"


### PR DESCRIPTION
Release 0.1.3 includes the previously pinned git revision